### PR TITLE
init docker-compose with api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,5 @@ WORKDIR /home/maprules
 # download dependencies
 RUN echo "DOWNLOAD DEPENDENCIES" \
     && apt-get update \
-    && apt-get install -yq sqlite3 libsqlite3-dev git \
-    && npm install 
-    
+    && apt-get install -yq sqlite3 libsqlite3-dev git
+RUN npm install && yarn build && NODE_ENV=development yarn fixture

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+
+services:
+  api:
+    build: .
+    ports:
+      - 3000:3000
+    entrypoint: "yarn dev"

--- a/index.js
+++ b/index.js
@@ -3,9 +3,9 @@
 const Hapi = require('hapi');
 const routes = require('./routes');
 
-const server = Hapi.server({ 
-    port: process.env.PORT || 3000, 
-    host: process.env.HOST || 'localhost',
+const server = Hapi.server({
+    port: process.env.PORT || 3000,
+    host: '0.0.0.0',
     routes: { cors: true }
 });
 


### PR DESCRIPTION
This is a start for #42 
It only contains the API because the UI has no `Dockerfile` for now


To use:
* build with `docker-compose build` 
* run with `docker-compose up` 
* you can then use the API at http://localhost:3000/config